### PR TITLE
perf(rules): parallelize rule validation

### DIFF
--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import os
 import re
@@ -432,18 +433,12 @@ def parse_config_files(
     """
     config = {}
     errors: List[SemgrepError] = []
-    # NOTE: This was pretty slow for directories with many rules. Now for 220+ rules
-    # a moderate repo scan took ~45s instead of ~55s, so a 20% improvement.
-    # XXX: One test fails, because we don't capture the output from the executor
-    # pool. But I manually tested that the expected error was printed, so it's a
-    # test configuration issue.
-    #
-    # for config_id, contents, config_path in loaded_config_infos:
-    from concurrent.futures import ThreadPoolExecutor
-    @tracing.trace()
-    def process_config_item(config_item):
-        config_id, contents, config_path = config_item
-        try:
+    future_to_config_id_and_path: Dict[
+        concurrent.futures.Future[Tuple[Dict[str, YamlTree], List[SemgrepError]]],
+        Tuple[str, str],
+    ] = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for config_id, contents, config_path in loaded_config_infos:
             if not config_id:  # registry rules don't have config ids
                 # Note: we must disambiguate registry sourced remote rules from
                 # non-registry sourced ones for security purposes. Namely, we
@@ -466,36 +461,33 @@ def parse_config_files(
                 filename = f"{config_path[:20]}..."
             else:
                 filename = config_path
-            config_data, config_errors = parse_config_string(
-                config_id, contents, filename, force_jsonschema=force_jsonschema
+            validation_future = executor.submit(
+                parse_config_string,
+                config_id,
+                contents,
+                filename,
+                force_jsonschema=force_jsonschema,
             )
-            return 'Ok', config_data, config_errors
-
-        except InvalidRuleSchemaError as e:
-            if (
-                config_id == REGISTRY_CONFIG_ID
-                or config_id == NON_REGISTRY_REMOTE_CONFIG_ID
-            ):
-                notice = f"\nRules downloaded from {config_path} failed to parse.\nThis is likely because rules have been added that use functionality introduced in later versions of semgrep.\nPlease upgrade to latest version of semgrep (see https://semgrep.dev/docs/upgrading/) and try again.\n"
-                notice_color = with_color(Colors.red, notice, bold=True)
-                logger.error(notice_color)
-                return 'Error', e
-            else:
-                return 'Error', e
-
-    with ThreadPoolExecutor() as executor:
-        results = list(executor.map(process_config_item, loaded_config_infos))
-
-    # Merge results
-    for res in results:
-        if res[0] == 'Ok':
-            config_data, config_errors = res[1:]
-            config.update(config_data)
-            errors.extend(config_errors)
-        else:
-            # Raise the first error:
-            raise res[1]
-
+            future_to_config_id_and_path[validation_future] = config_id, config_path
+        for future in concurrent.futures.as_completed(
+            future_to_config_id_and_path, timeout=5 * 60
+        ):
+            config_id, config_path = future_to_config_id_and_path[future]
+            try:
+                config_data, config_errors = future.result()
+                config.update(config_data)
+                errors.extend(config_errors)
+            except InvalidRuleSchemaError as e:
+                if (
+                    config_id == REGISTRY_CONFIG_ID
+                    or config_id == NON_REGISTRY_REMOTE_CONFIG_ID
+                ):
+                    notice = f"\nRules downloaded from {config_path} failed to parse.\nThis is likely because rules have been added that use functionality introduced in later versions of semgrep.\nPlease upgrade to latest version of semgrep (see https://semgrep.dev/docs/upgrading/) and try again.\n"
+                    notice_color = with_color(Colors.red, notice, bold=True)
+                    logger.error(notice_color)
+                    raise e
+                else:
+                    raise e
     return config, errors
 
 


### PR DESCRIPTION
This PR is a direct backport of https://github.com/semgrep/semgrep/commit/f07c4e4

### Test plan

Existing end-to-end tests should validate that user-facing behavior does not change.

The performance improvement was validated by running a semgrep scan on a repository with a single code file using a clone of the `semgrep_rules` repository as the rule source.

After cloning, the `semgrep_rules` repository was modified to remove any YAML files that are not semgrep rules, including `.github`,`stats` and `.pre-commit-config.yaml`.

The results of `hyperfine opengrep scan --config semgrep-rules single/file/path` are:

Without this PR's changes:

```
  Time (mean ± σ):     25.001 s ±  0.897 s    [User: 134.339 s, System: 49.526 s]
  Range (min … max):   24.550 s … 27.525 s    10 runs
```

With this PR's changes:

```
  Time (mean ± σ):     24.894 s ±  0.282 s    [User: 132.791 s, System: 49.099 s]
  Range (min … max):   24.512 s … 25.616 s    10 runs
```

The improvements might be negligible but they could allow to align the file to upstream for easier backport of future fixes or improvements

Signed-off-by: Leyart <leyart@gmail.com>
